### PR TITLE
Support for configuring the provider base URL

### DIFF
--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -60,7 +60,7 @@ class Plugin extends BasePlugin
     /**
      * @var string
      */
-    public $schemaVersion = '1.0.0';
+    public $schemaVersion = '1.1.0';
     public $hasCpSettings = true;
 
     // Public Methods
@@ -188,6 +188,7 @@ class Plugin extends BasePlugin
                 'provider' => $app->provider,
                 'clientId' => $app->clientId,
                 'clientSecret' => $app->clientSecret,
+                'urlAuthorize' => $app->urlAuthorize,
                 'scopes' => $app->scopes
             ];
         }

--- a/src/base/Provider.php
+++ b/src/base/Provider.php
@@ -47,7 +47,8 @@ abstract class Provider extends Component implements ProviderInterface
         return [
             'clientId' => $this->getApp()->getClientId(),
             'clientSecret' => $this->getApp()->getClientSecret(),
-            'redirectUri' => $this->getApp()->getRedirectUrl()
+            'redirectUri' => $this->getApp()->getRedirectUrl(),
+            'urlAuthorize' => $this->getApp()->getUrlAuthorize()
         ];
     }
 

--- a/src/controllers/AppsController.php
+++ b/src/controllers/AppsController.php
@@ -140,6 +140,7 @@ class AppsController extends Controller
             'handle' => $request->getRequiredBodyParam('handle'),
             'clientId' => $request->getRequiredBodyParam('clientId'),
             'clientSecret' => $request->getRequiredBodyParam('clientSecret'),
+            'urlAuthorize' => $request->getRequiredBodyParam('urlAuthorize'),
             'scopes' => $scopes
         ];
 

--- a/src/migrations/Install.php
+++ b/src/migrations/Install.php
@@ -101,6 +101,7 @@ class Install extends Migration
                     'provider' => $this->string(255)->notNull(),
                     'clientId' => $this->text(),
                     'clientSecret' => $this->text(),
+                    'urlAuthorize' => $this->text(),
                     'scopes' => $this->text(),
                 ]
             );

--- a/src/migrations/add_url_authorize.php
+++ b/src/migrations/add_url_authorize.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace craft\contentmigrations;
+namespace venveo\oauthclient\migrations;
 
 use Craft;
 use craft\db\Migration;

--- a/src/migrations/add_url_authorize.php
+++ b/src/migrations/add_url_authorize.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace craft\contentmigrations;
+
+use Craft;
+use craft\db\Migration;
+
+/**
+ * add_url_authorize migration.
+ */
+class add_url_authorize extends Migration
+{
+    /**
+     * @inheritdoc
+     */
+    public function safeUp()
+    {
+        $this->addColumn('{{%oauthclient_apps}}', 'urlAuthorize', $this->text());
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function safeDown()
+    {
+        $this->dropColumn('{{%oauthclient_apps}}', 'urlAuthorize');
+    }
+}

--- a/src/migrations/m200113_014806_add_url_authorize.php
+++ b/src/migrations/m200113_014806_add_url_authorize.php
@@ -6,9 +6,9 @@ use Craft;
 use craft\db\Migration;
 
 /**
- * add_url_authorize migration.
+ * m200113_014806_add_url_authorize migration.
  */
-class add_url_authorize extends Migration
+class m200113_014806_add_url_authorize extends Migration
 {
     /**
      * @inheritdoc

--- a/src/migrations/m200113_014806_add_url_authorize.php
+++ b/src/migrations/m200113_014806_add_url_authorize.php
@@ -15,7 +15,7 @@ class m200113_014806_add_url_authorize extends Migration
      */
     public function safeUp()
     {
-        $this->addColumn('{{%oauthclient_apps}}', 'urlAuthorize', $this->text());
+        $this->addColumn('{{%oauthclient_apps}}', 'urlAuthorize', $this->text()->after('clientSecret'));
     }
 
     /**

--- a/src/models/App.php
+++ b/src/models/App.php
@@ -36,6 +36,7 @@ class App extends Model
     public $handle;
     public $clientId;
     public $clientSecret;
+    public $urlAuthorize;
 
     public $isNew;
 
@@ -69,6 +70,16 @@ class App extends Model
     public function getClientSecret(): string
     {
         return \Craft::parseEnv($this->clientSecret);
+    }
+    
+    /**
+     * Returns the custom authorization URL.
+     *
+     * @return string
+     */
+    public function getUrlAuthorize(): string
+    {
+        return (string)$this->urlAuthorize;
     }
 
     /**

--- a/src/records/App.php
+++ b/src/records/App.php
@@ -28,6 +28,7 @@ use yii\db\ActiveQueryInterface;
  * @property string $handle
  * @property string $clientId
  * @property string $clientSecret
+ * @property string $urlAuthorize
  * @property User $user
  * @property \yii\db\ActiveQueryInterface $tokens
  * @property string $scopes

--- a/src/services/Apps.php
+++ b/src/services/Apps.php
@@ -208,6 +208,7 @@ class Apps extends Component
                 'dateUpdated',
                 'clientId',
                 'clientSecret',
+                'urlAuthorize',
                 'scopes',
                 'handle'
             ])
@@ -254,6 +255,7 @@ class Apps extends Component
             'provider' => $app->provider,
             'clientId' => $app->clientId,
             'clientSecret' => $app->clientSecret,
+            'urlAuthorize' => $app->urlAuthorize,
             'scopes' => $app->scopes,
         ]);
 
@@ -293,6 +295,7 @@ class Apps extends Component
                     'provider' => $event->newValue['provider'],
                     'clientId' => $event->newValue['clientId'],
                     'clientSecret' => $event->newValue['clientSecret'],
+                    'urlAuthorize' => $event->newValue['urlAuthorize'],
                     'scopes' => $event->newValue['scopes'],
                 ])
                 ->execute();
@@ -304,6 +307,7 @@ class Apps extends Component
                     'provider' => $event->newValue['provider'],
                     'clientId' => $event->newValue['clientId'],
                     'clientSecret' => $event->newValue['clientSecret'],
+                    'urlAuthorize' => $event->newValue['urlAuthorize'],
                     'scopes' => $event->newValue['scopes'],
                 ], ['id' => $id])
                 ->execute();

--- a/src/templates/apps/_edit.twig
+++ b/src/templates/apps/_edit.twig
@@ -70,6 +70,16 @@
     required: true,
     errors: app.getErrors('clientSecret'),
   }) }}
+  
+  {{ forms.textField({
+    label: 'Authorize URL'|t('oauthclient'),
+    instructions: 'The custom authorization URL, if different from the provider default.',
+    name: 'urlAuthorize',
+    id: 'urlAuthorize',
+    value : app.urlAuthorize,
+    required: false,
+    errors: app.getErrors('urlAuthorize'),
+  }) }}
 
   {{ forms.selectField({
     first: true,


### PR DESCRIPTION
This PR adds support for configuring the the base authorization URL via settings, for League OAuth providers that support overriding it, ex:

```php
$provider = new \League\OAuth2\Client\Provider\GenericProvider([
    'urlAuthorize' => 'http://brentertainment.com/oauth2/lockdin/authorize',
]);
```

If the field is left blank, the default `urlAuthorize` setting is used, so the initial setup is the same as now. I’m using a provider where it’s necessary to change the base URL, and from my understanding of the same providers, it is possible to make them without a default authorization URL at all.

<img width="521" alt="Screenshot 2019-12-17 22 21 33" src="https://user-images.githubusercontent.com/1581276/71061593-35498400-211d-11ea-8987-e2117fc83ec6.png">

Thanks for the great work on this plugin!