### PR TITLE
Adds the original response as something passed along to token events

### DIFF
--- a/src/models/Token.php
+++ b/src/models/Token.php
@@ -33,6 +33,7 @@ class Token extends Model implements AccessTokenInterface
     public $expiryDate;
     public $refreshToken;
     public $accessToken;
+    public $response;
     public $uid;
 
     private $tokenValues;
@@ -47,7 +48,8 @@ class Token extends Model implements AccessTokenInterface
         return new self([
             'accessToken' => $token->getToken(),
             'refreshToken' => $token->getRefreshToken(),
-            'expiryDate' => $token->getExpires()
+            'expiryDate' => $token->getExpires(),
+            'response' => $token
         ]);
     }
 


### PR DESCRIPTION
In the integration I’m making, I found there was extra information from Stripe I needed to save from the original token response.

This adds that original token as `response`, so it’s accessible via events.

If you’d prefer, I could add a new `EVENT_BEFORE_TOKEN_RESPONSE_MODIFIED` event or similar instead, before the token is passed to `TokenModel::fromLeagueToken()`

Or, open to other suggestions if this is already possible to work around and I’m missing something. Thanks!