### PR TITLE
Fix a reference to the wrong provider class

### DIFF
--- a/src/controllers/AuthorizeController.php
+++ b/src/controllers/AuthorizeController.php
@@ -92,7 +92,7 @@ class AuthorizeController extends Controller
         ]);
 
         // We need to save the token
-        $token = $configuredProvider->createTokenModelFromResponse($tokenResponse);
+        $token = $provider->createTokenModelFromResponse($tokenResponse);
         $token->appId = $app->id;
         $token->userId = Craft::$app->user->getId();
 


### PR DESCRIPTION
The `createTokenModelFromResponse` method is only available on `venveo\oauthclient\base\Provider`, thus configured providers will error out when triggering the callback URL as they don’t have that method.