### PR TITLE
Small fixes for the authorize url

### DIFF
--- a/src/base/Provider.php
+++ b/src/base/Provider.php
@@ -79,12 +79,18 @@ abstract class Provider extends Component implements ProviderInterface
      */
     public function getProviderOptions(): array
     {
-        return [
+        $urlAuthorize = $this->getApp()->getUrlAuthorize();
+        $result = [
             'clientId' => $this->getApp()->getClientId(),
             'clientSecret' => $this->getApp()->getClientSecret(),
             'redirectUri' => $this->getApp()->getRedirectUrl(),
-            'urlAuthorize' => $this->getApp()->getUrlAuthorize()
         ];
+        
+        if ($urlAuthorize) {
+          $result['urlAuthorize'] = $urlAuthorize;
+        }
+
+        return $result;
     }
 
     /**

--- a/src/models/App.php
+++ b/src/models/App.php
@@ -86,7 +86,7 @@ class App extends Model
      */
     public function getUrlAuthorize(): string
     {
-        return Craft::parseEnv($this->clientSecret);
+        return Craft::parseEnv($this->urlAuthorize);
     }
 
     /**


### PR DESCRIPTION
- `getUrlAuthorize` is currently returning the `clientSecret` after getting support for environment variables
- Probably for the best in the meantime, because I shouldn’t have included `urlAuthorize` in `getProviderOptions` if it doesn’t exist

With those fixes, overriding the default URL works great.

I like what you came up with for showing the advanced settings too. Thanks!

Now that I have spent a bit more time with the plugin, I realized I could also achieve the same thing by modifying the base url on the provider before wrapping it—but I suppose this is still a way to do the same thing purely through the settings pane, which is convenient.