### PR TITLE
Adds the option to send the redirect URL via context

### DIFF
--- a/src/controllers/AuthorizeController.php
+++ b/src/controllers/AuthorizeController.php
@@ -37,11 +37,17 @@ class AuthorizeController extends Controller
      */
     public function actionAuthorizeApp($handle): Response
     {
+        $context = Craft::$app->request->getParam('context');
+        $redirectUrl = null;
+
         if (Craft::$app->request->isPost) {
             $redirectUrl = Craft::$app->getRequest()->getValidatedBodyParam('redirect');
-            if ($redirectUrl) {
-                Craft::$app->session->set('OAUTH_REDIRECT_URL', $redirectUrl);
-            }
+        } else if ($context && $context['redirect']) {
+            $redirectUrl = $context['redirect'];
+        }
+        
+        if ($redirectUrl) {
+            Craft::$app->session->set('OAUTH_REDIRECT_URL', $redirectUrl);
         }
 
         /** @var  $app */
@@ -53,7 +59,6 @@ class AuthorizeController extends Controller
 
         $this->requirePermission('oauthclient-login:' . $app->uid);
 
-        $context = Craft::$app->request->getParam('context');
         $error = Craft::$app->request->getParam('error');
         $code = Craft::$app->request->getParam('code');
         $state = Craft::$app->request->getParam('state');


### PR DESCRIPTION
I was looking for a way to set the redirect after the OAuth flow when making the link as a link, rather than a form submission. The place I’m adding the link is already inside a form in the Craft control panel, similar to the “+” add Token button in the plugin UI, so it isn’t practical to make it a form.

Would adding the redirect URL to the context + this PR, be a reasonable way to add that functionality?

```twig
{% set context = {
  redirect: "https://example.com"
} %}

<a href="{{ app.getRedirectUrl(context) }}">Connect</a>
```

Or is it intentionally only done via a POST request right now?

Alternatively, could this be done in the `EVENT_GET_URL_OPTIONS` event?

Another option that might solve it for me would be to make the default redirect value the page you were originally on, rather than `oauthclient/apps`.

I can open a different PR if any of those other approaches sound more appealing to you, or maybe I am missing something. Thanks very much!