### PR TITLE
Updates minimum versions of OAuth deps

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,9 +24,9 @@
   "require": {
     "craftcms/cms": "^3.1.34.3",
     "league/oauth2-client": "^2.2.1",
-    "league/oauth2-google": "^2.2",
+    "league/oauth2-google": "^2.2 || ^3.0",
     "league/oauth2-facebook": "^2.0",
-    "league/oauth2-github": "^2.0"
+    "league/oauth2-github": "^2.0 || ^3.0"
   },
   "autoload": {
     "psr-4": {


### PR DESCRIPTION
This Pull Request makes it possible to install the plugin alongside other plugins using more recent versions of the Google or GitHub OAuth plugins.This issue originally came up here: https://github.com/kennethormandy/craft-marketplace/issues/20

From the changelogs, it didn’t appear that this would have API changes that would impact this plugin, but I am not 100% sure about that.

- [thephpleague/oauth2-google changelog](https://github.com/thephpleague/oauth2-google/blob/main/CHANGELOG.md#300---2018-12-23)
- [thephpleague/oauth2-github changelog](https://github.com/thephpleague/oauth2-github/blob/main/CHANGELOG.md#300---2021-05-10)

For the Google plugin, it might be fine to add v4.x to the allowed range too.

Thanks!